### PR TITLE
fix: import image component and tidy detail ticket form

### DIFF
--- a/src/components/Beranda/Ticket/DetailTikcket/DetailTicketForm.jsx
+++ b/src/components/Beranda/Ticket/DetailTikcket/DetailTicketForm.jsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState, useRef, useEffect } from "react";
-import dynamic from "next/dynamic";
+import Image from "next/image";
 import CKEditorWrapper from "@/components/CKEditorWrapper";
-import { useTheme } from "@emotion/react";
 
 export default function DetailTicketForm({ data }) {
   const [form, setForm] = useState({
@@ -25,10 +24,6 @@ export default function DetailTicketForm({ data }) {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
-  };
-
-  const handleChangeDeskripsiTiket = (name, value) => {
     setForm({ ...form, [name]: value });
   };
 


### PR DESCRIPTION
## Summary
- add missing `next/image` import in DetailTicketForm component
- remove unused imports and redundant handler in ticket detail form

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897644337a88332962fa3fad19b0e94