### PR TITLE
fix: clean ticket detail component structure

### DIFF
--- a/src/app/beranda/ticket-details/[no]/page.jsx
+++ b/src/app/beranda/ticket-details/[no]/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import DetailTicketForm from "@/components/Beranda/Ticket/DetailTikcket/DetailTicketForm";
+import DetailTicketForm from "@/components/Beranda/Ticket/DetailTicket/DetailTicketForm";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import { useParams } from "next/navigation";
 import React from "react";

--- a/src/components/Beranda/Ticket/DetailTicket/DetailTicketForm.jsx
+++ b/src/components/Beranda/Ticket/DetailTicket/DetailTicketForm.jsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState, useRef, useEffect } from "react";
-import dynamic from "next/dynamic";
+import Image from "next/image";
 import CKEditorWrapper from "@/components/CKEditorWrapper";
-import { useTheme } from "@emotion/react";
 
 export default function DetailTicketForm({ data }) {
   const [form, setForm] = useState({
@@ -25,10 +24,6 @@ export default function DetailTicketForm({ data }) {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
-  };
-
-  const handleChangeDeskripsiTiket = (name, value) => {
     setForm({ ...form, [name]: value });
   };
 


### PR DESCRIPTION
## Summary
- add missing `next/image` import in DetailTicketForm and remove unused code
- rename misspelled `DetailTikcket` folder to `DetailTicket` and update imports

## Testing
- `npm run lint`
- `npm test` (fails: Missing script)
- `npx next build` (hangs after "Creating an optimized production build ...")


------
https://chatgpt.com/codex/tasks/task_e_6897644337a88332962fa3fad19b0e94