### PR TITLE
style: standardize beranda page layouts

### DIFF
--- a/src/app/beranda/contact-us/page.jsx
+++ b/src/app/beranda/contact-us/page.jsx
@@ -2,11 +2,13 @@ import ContactUs from "@/components/Beranda/ContactUs/ContactUs";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col h-screen">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <ContactUs />
+        <div className="flex flex-col py-6 px-14">
+          <ContactUs />
+        </div>
       </MainLayout>
     </div>
   );

--- a/src/app/beranda/dokumen/bag-cloud/page.jsx
+++ b/src/app/beranda/dokumen/bag-cloud/page.jsx
@@ -2,11 +2,11 @@ import BagCloudTable from "@/components/Beranda/Dokumen/BagCloudTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <BagCloudTable />
         </div>

--- a/src/app/beranda/dokumen/e-procurement/page.jsx
+++ b/src/app/beranda/dokumen/e-procurement/page.jsx
@@ -2,11 +2,11 @@ import EProcurementTable from "@/components/Beranda/Dokumen/EProcurementTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <EProcurementTable />
         </div>

--- a/src/app/beranda/dokumen/email/page.jsx
+++ b/src/app/beranda/dokumen/email/page.jsx
@@ -2,11 +2,11 @@ import EmailTable from "@/components/Beranda/Dokumen/EmailTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <EmailTable />
         </div>

--- a/src/app/beranda/dokumen/erp-crm/page.jsx
+++ b/src/app/beranda/dokumen/erp-crm/page.jsx
@@ -2,11 +2,11 @@ import ErpCrmTable from "@/components/Beranda/Dokumen/ErpCrmTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <ErpCrmTable />
         </div>

--- a/src/app/beranda/dokumen/erp-fm/page.jsx
+++ b/src/app/beranda/dokumen/erp-fm/page.jsx
@@ -2,11 +2,11 @@ import ErpFmTable from "@/components/Beranda/Dokumen/ErpFmTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <ErpFmTable />
         </div>

--- a/src/app/beranda/dokumen/erp-hcm/page.jsx
+++ b/src/app/beranda/dokumen/erp-hcm/page.jsx
@@ -2,11 +2,11 @@ import ErpHcmTable from "@/components/Beranda/Dokumen/ErpHcmTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <ErpHcmTable />
         </div>

--- a/src/app/beranda/dokumen/erp-mm/page.jsx
+++ b/src/app/beranda/dokumen/erp-mm/page.jsx
@@ -2,11 +2,11 @@ import ErpMmTable from "@/components/Beranda/Dokumen/ErpMmTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <ErpMmTable />
         </div>

--- a/src/app/beranda/dokumen/fuel-mentoring/page.jsx
+++ b/src/app/beranda/dokumen/fuel-mentoring/page.jsx
@@ -2,11 +2,11 @@ import FuelMentoringTable from "@/components/Beranda/Dokumen/FuelMentoringTable"
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <FuelMentoringTable />
         </div>

--- a/src/app/beranda/dokumen/page.jsx
+++ b/src/app/beranda/dokumen/page.jsx
@@ -4,7 +4,7 @@ import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 import { useRouter } from "next/navigation";
 
-export default function page() {
+export default function Page() {
   const router = useRouter();
 
   const handleNavigateTo = (path) => {
@@ -12,9 +12,9 @@ export default function page() {
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <ApplicationService handleNavigate={handleNavigateTo} />
         </div>

--- a/src/app/beranda/dokumen/pms/page.jsx
+++ b/src/app/beranda/dokumen/pms/page.jsx
@@ -2,11 +2,11 @@ import PmsTable from "@/components/Beranda/Dokumen/PmsTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <PmsTable />
         </div>

--- a/src/app/beranda/dokumen/ship-tracking/page.jsx
+++ b/src/app/beranda/dokumen/ship-tracking/page.jsx
@@ -2,11 +2,11 @@ import ShipTrackingTable from "@/components/Beranda/Dokumen/ShipTrackingTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <ShipTrackingTable />
         </div>

--- a/src/app/beranda/dokumen/website/page.jsx
+++ b/src/app/beranda/dokumen/website/page.jsx
@@ -2,11 +2,11 @@ import WebsiteTable from "@/components/Beranda/Dokumen/WebsiteTable";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">Dokumen</h1>
           <WebsiteTable />
         </div>

--- a/src/app/beranda/faq/page.jsx
+++ b/src/app/beranda/faq/page.jsx
@@ -2,11 +2,11 @@ import FAQAccordion from "@/components/Beranda/FAQ/FAQAccordion";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function faq() {
+export default function Page() {
   return (
-    <div className="flex flex-col ">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+        <div className="flex flex-col py-6 px-14 space-y-4">
           <h1 className="text-2xl font-bold">FAQ</h1>
           <FAQAccordion />
         </div>

--- a/src/app/beranda/formulir/page.jsx
+++ b/src/app/beranda/formulir/page.jsx
@@ -4,7 +4,7 @@ import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   const router = useRouter();
 
   const handleNavigate = (path) => {
@@ -12,9 +12,12 @@ export default function page() {
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <FormulirTable handleOpenForm={handleNavigate} />
+        <div className="flex flex-col py-6 px-14">
+          <h1 className="text-2xl font-bold mb-4">Formulir</h1>
+          <FormulirTable handleOpenForm={handleNavigate} />
+        </div>
       </MainLayout>
     </div>
   );

--- a/src/app/beranda/formulir/pakta-integritas/page.jsx
+++ b/src/app/beranda/formulir/pakta-integritas/page.jsx
@@ -1,5 +1,15 @@
+import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
-  return <div>page</div>;
+export default function Page() {
+  return (
+    <div className="bg-slate-100 min-h-screen">
+      <MainLayout>
+        <div className="flex flex-col py-6 px-14">
+          <h1 className="text-2xl font-bold mb-4">Formulir</h1>
+          <div>page</div>
+        </div>
+      </MainLayout>
+    </div>
+  );
 }

--- a/src/app/beranda/formulir/uaa-01/page.jsx
+++ b/src/app/beranda/formulir/uaa-01/page.jsx
@@ -4,11 +4,11 @@ import React from "react";
 import logoKop from "../../../../assets/logoNavbar.png";
 import Image from "next/image";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-auto">
+        <div className="flex flex-col py-6 px-14 h-auto">
           <h1 className="text-2xl font-bold mb-4">Formulir</h1>
           <div className="bg-white rounded-xl p-4">
             <form className="bg-white rounded-xl shadow p-6 space-y-6 text-sm text-gray-700">

--- a/src/app/beranda/formulir/uaa-02/page.jsx
+++ b/src/app/beranda/formulir/uaa-02/page.jsx
@@ -4,11 +4,11 @@ import React from "react";
 import logoKop from "../../../../assets/logoNavbar.png";
 import Image from "next/image";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-auto">
+        <div className="flex flex-col py-6 px-14 h-auto">
           <h1 className="text-2xl font-bold mb-4">Formulir</h1>
           <div className="bg-white rounded-xl p-4">
             <form className="bg-white rounded-xl shadow p-6 space-y-6 text-sm text-gray-700">

--- a/src/app/beranda/formulir/uaa-03/page.jsx
+++ b/src/app/beranda/formulir/uaa-03/page.jsx
@@ -4,11 +4,11 @@ import React from "react";
 import logoKop from "../../../../assets/logoNavbar.png";
 import Image from "next/image";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-auto">
+        <div className="flex flex-col py-6 px-14 h-auto">
           <h1 className="text-2xl font-bold mb-4">Formulir</h1>
           <div className="bg-white rounded-xl p-4">
             <form className="bg-white rounded-xl shadow p-6 space-y-6 text-sm text-gray-700">

--- a/src/app/beranda/formulir/uaa-04/page.jsx
+++ b/src/app/beranda/formulir/uaa-04/page.jsx
@@ -4,11 +4,11 @@ import React from "react";
 import logoKop from "../../../../assets/logoNavbar.png";
 import Image from "next/image";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="flex flex-col h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="bg-slate-100 py-6 px-14 h-auto">
+        <div className="flex flex-col py-6 px-14 h-auto">
           <h1 className="text-2xl font-bold mb-4">Formulir</h1>
           <div className="bg-white rounded-xl p-4">
             <form className="bg-white rounded-xl shadow p-6 space-y-6 text-sm text-gray-700">

--- a/src/app/beranda/new-ticket/page.jsx
+++ b/src/app/beranda/new-ticket/page.jsx
@@ -2,11 +2,11 @@ import TicketForm from "@/components/Beranda/Ticket/NewTicket/TicketForm";
 import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   return (
-    <div className="bg-slate-100 h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="flex flex-col gap-6 py-6 px-10">
+        <div className="flex flex-col gap-6 py-6 px-14">
           <h1 className="text-2xl font-bold">Beranda</h1>
           <TicketForm />
         </div>

--- a/src/app/beranda/page.jsx
+++ b/src/app/beranda/page.jsx
@@ -14,7 +14,7 @@ export default function Page() {
     router.push(`/beranda/ticket-details/${index}`, { state: item });
   };
   return (
-    <div className="bg-slate-100 h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
         <div className="flex flex-col py-6 px-14">
           <h1 className="text-2xl font-bold mb-6">Beranda</h1>

--- a/src/app/beranda/ticket-details/[no]/page.jsx
+++ b/src/app/beranda/ticket-details/[no]/page.jsx
@@ -4,7 +4,7 @@ import MainLayout from "@/components/Beranda/Layout/MainLayout";
 import { useParams } from "next/navigation";
 import React from "react";
 
-export default function page() {
+export default function Page() {
   const params = useParams();
   const ticketNo = params.no;
 
@@ -66,9 +66,9 @@ export default function page() {
   };
 
   return (
-    <div className="bg-slate-100 min-h-screen h-full">
+    <div className="bg-slate-100 min-h-screen">
       <MainLayout>
-        <div className="flex flex-col gap-6 py-6 px-10">
+        <div className="flex flex-col gap-6 py-6 px-14">
           <div className="flex justify-between items-center">
             <h1 className="text-2xl font-bold">Beranda</h1>
             <button className="text-white bg-sky-400 px-4 py-2 rounded-2xl">

--- a/src/components/Beranda/ContactUs/ContactUs.jsx
+++ b/src/components/Beranda/ContactUs/ContactUs.jsx
@@ -11,7 +11,7 @@ import {
 
 export default function ContactUs() {
   return (
-    <div className="bg-slate-100 py-6 px-14 h-full space-y-4">
+    <div className="space-y-4">
       <h1 className="text-2xl font-bold">Hubungi Helpdesk</h1>
       <div className="bg-white rounded-lg shadow-md p-4">
         {/* Jam Operasional */}

--- a/src/components/Beranda/Home/HeroImg.jsx
+++ b/src/components/Beranda/Home/HeroImg.jsx
@@ -5,7 +5,7 @@ import HeroImge from "../../../assets/heroImg.png";
 export default function HeroImg() {
   return (
     <div className="flex justify-center items-center">
-      <Image src={HeroImge} alt="Hero" width="auto" className="w-full" />
+      <Image src={HeroImge} alt="Hero" className="w-full h-auto" priority />
     </div>
   );
 }

--- a/src/components/Beranda/Home/HomeContactUs.jsx
+++ b/src/components/Beranda/Home/HomeContactUs.jsx
@@ -25,25 +25,25 @@ export default function HomeContactUs() {
     window.location.href = phoneUrl;
   };
 
+  const iconButtonClass =
+    "rounded-full p-2 bg-[#65C7D5]/10 hover:bg-[#65C7D5]/20 cursor-pointer transition-all duration-300";
+
   return (
     <div className="bg-white py-6 px-5 flex items-center gap-4">
-      <h2 className="text-black font-normal text-sm">
+      <h2 className="text-black text-sm font-normal">
         Pengguna Dapat Menghubungi Service Helpdesk :
       </h2>
-      <button className="rounded-full p-2 bg-[#65C7D514] hover:bg-sky-100 cursor-pointer transition-all duration-300 ">
-        <IoMailOpen onClick={onClickMail} className="text-[#65C7D5] text-2xl" />
+      <button className={iconButtonClass} onClick={onClickMail}>
+        <IoMailOpen className="text-[#65C7D5] text-2xl" />
       </button>
-      <button className="rounded-full p-2 bg-[#65C7D514] hover:bg-sky-100 cursor-pointer transition-all duration-300">
-        <BiWorld onClick={onClickWebsite} className="text-[#65C7D5] text-2xl" />
+      <button className={iconButtonClass} onClick={onClickWebsite}>
+        <BiWorld className="text-[#65C7D5] text-2xl" />
       </button>
-      <button className="rounded-full p-2 bg-[#65C7D514] hover:bg-sky-100 cursor-pointer transition-all duration-300">
-        <RiWhatsappFill
-          onClick={onClickWhatsapp}
-          className="text-[#65C7D5] text-2xl"
-        />
+      <button className={iconButtonClass} onClick={onClickWhatsapp}>
+        <RiWhatsappFill className="text-[#65C7D5] text-2xl" />
       </button>
-      <button className="rounded-full p-2 bg-[#65C7D514] hover:bg-sky-100 cursor-pointer transition-all duration-300">
-        <IoCall onClick={onClickCall} className="text-[#65C7D5] text-xl" />
+      <button className={iconButtonClass} onClick={onClickCall}>
+        <IoCall className="text-[#65C7D5] text-xl" />
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- add common bg/padding wrapper and capitalize components across beranda pages
- move contact-us layout styling to page component for consistency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689986038ce4833280b6d498d54e4155